### PR TITLE
fix: unaligned icon in DropdownSubTrigger

### DIFF
--- a/src/components/ui/dropdown.tsx
+++ b/src/components/ui/dropdown.tsx
@@ -147,7 +147,7 @@ const DropdownSubTrigger = React.forwardRef<
 	<Menu.SubmenuTrigger
 		ref={ref}
 		className={cn(
-			"flex select-none items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-accent data-[popup-open]:bg-accent data-[highlighted]:text-accent-foreground data-[popup-open]:text-accent-foreground data-[disabled]:opacity-50",
+			"flex select-none items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-none data-[disabled]:pointer-events-none data-[highlighted]:bg-accent data-[popup-open]:bg-accent data-[highlighted]:text-accent-foreground data-[popup-open]:text-accent-foreground data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
 			className
 		)}
 		{...props}


### PR DESCRIPTION
Eyo! Thanks for a cool library. Found a tiny winy minor improvement

- Updated `DropdownSubTrigger` to include default styling for svg elements, making it css equivalent to the DropdownItem. Results in consistent aligned icons, if an icon is used in a DropdownSubTrigger.