### PR TITLE
Do not call TooltipProvider for every Tooltip

### DIFF
--- a/apps/2x/src/components/ui/tooltip.tsx
+++ b/apps/2x/src/components/ui/tooltip.tsx
@@ -20,9 +20,7 @@ function TooltipProvider({
 
 function Tooltip({ ...props }: React.ComponentProps<typeof BaseTooltip.Root>) {
 	return (
-		<TooltipProvider>
-			<BaseTooltip.Root data-slot="tooltip" {...props} />
-		</TooltipProvider>
+		<BaseTooltip.Root data-slot="tooltip" {...props} />
 	)
 }
 


### PR DESCRIPTION
Do not call TooltipProvider for every Tooltip, because you won’t be able to set the delay for a tooltip or tooltip group.