### PR TITLE
fix(input): always disabled when passing value to `disabled`

### DIFF
--- a/apps/2x/src/components/ui/input.tsx
+++ b/apps/2x/src/components/ui/input.tsx
@@ -24,7 +24,7 @@ function Input({
 				"group relative w-full data-[disabled]:pointer-events-none",
 				inputContainerClassName
 			)}
-			data-disabled={disabled}
+			data-disabled={disabled ? "" : undefined}
 			data-slot="input-container"
 		>
 			{leadingIcon && (


### PR DESCRIPTION
The wrapper’s data-disabled attribute is now only rendered when disabled is truthy. The `data-[disabled]:pointer-events-none` rule will disable every input even when `disabled` set to false.