### PR TITLE
Replace 'input' with BaseUI Input

### DIFF
--- a/apps/2x/src/components/ui/input.tsx
+++ b/apps/2x/src/components/ui/input.tsx
@@ -3,7 +3,7 @@ import { Input as BaseInput } from '@base-ui-components/react/input'
 
 import { cn } from "@/lib/utils"
 
-interface InputProps extends React.ComponentProps<"input"> {
+interface InputProps extends React.ComponentProps<typeof BaseInput> {
 	inputContainerClassName?: string
 	leadingIcon?: React.ReactNode
 	trailingIcon?: React.ReactNode


### PR DESCRIPTION
Using the BaseUI Input component allows it to work with the BaseUI Field component.