### PR TITLE
Add style property to components.json example

### DIFF
--- a/apps/2x/src/content/getting-started/installation.mdx
+++ b/apps/2x/src/content/getting-started/installation.mdx
@@ -285,6 +285,7 @@ Optionally create a `components.json` file to enable shadcn CLI component instal
 ```json title="components.json"
 {
 	"$schema": "https://ui.shadcn.com/schema.json",
+	"style": "new-york",
 	"rsc": false,
 	"tsx": true,
 	"tailwind": {


### PR DESCRIPTION
This PR addresses a bug where the components.json content in the manual setup guide is missing the `style` property.

Fixes #58