### PR TITLE
fix(docs): add DialogClose to dialog examples

### DIFF
--- a/apps/2x/src/components/demos/dialog/dialog-demo.tsx
+++ b/apps/2x/src/components/demos/dialog/dialog-demo.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button"
 import {
 	Dialog,
+	DialogClose,
 	DialogContent,
 	DialogDescription,
 	DialogFooter,
@@ -64,7 +65,13 @@ export default function DialogDemo() {
 					arcu, fermentum scelerisque nibh at, lacinia sagittis neque.
 				</div>
 				<DialogFooter>
-					<Button className="w-full">Accept</Button>
+					<DialogClose
+						render={(props) => (
+							<Button {...props} className="w-full">
+								Accept
+							</Button>
+						)}
+					/>
 				</DialogFooter>
 			</DialogContent>
 		</Dialog>

--- a/apps/2x/src/components/demos/dialog/dialog-nested.tsx
+++ b/apps/2x/src/components/demos/dialog/dialog-nested.tsx
@@ -55,7 +55,9 @@ export default function DialogNested() {
 										</Button>
 									)}
 								/>
-								<Button>Save</Button>
+								<DialogClose
+									render={(props) => <Button {...props}>Save</Button>}
+								/>
 							</DialogFooter>
 						</DialogContent>
 					</Dialog>


### PR DESCRIPTION
Fixes https://github.com/borabaloglu/9ui/issues/63
## Description
Updated `dialog-demo.tsx` and `dialog-nested.tsx` to wrap action buttons ("Accept", "Save", "Cancel") in `DialogClose`. This ensures the dialog closes when these buttons are clicked, as expected in the documentation.
## Changes
- Wrapped "Accept" button in `DialogClose` in `dialog-demo.tsx`.
- Wrapped "Save" and "Cancel" buttons in `DialogClose` in `dialog-nested.tsx`.